### PR TITLE
Replace deprecated ember-cli/ext/promise with rsvp

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /* jshint node: true */
 'use strict';
 
-var Promise = require('ember-cli/lib/ext/promise');
+var RSVP = require('rsvp');
 
 var sendDeployData = function(assets, config, target) {
   var dogapi = require('dogapi');
@@ -20,7 +20,7 @@ var sendDeployData = function(assets, config, target) {
 
   var now = parseInt(new Date().getTime() / 1000);
 
-  return new Promise(function(resolve, reject) {
+  return new RSVP.Promise(function(resolve, reject) {
     let metrics = [];
     for (let i = 0; i < pushedAssets.length; i++) {
       let asset = pushedAssets[i];
@@ -73,7 +73,7 @@ module.exports = {
           outputPath: outputPath
         });
 
-        var makeAssetSizesObject
+        var makeAssetSizesObject;
 
         if (typeof sizePrinter.makeAssetSizesObject !== 'undefined') {
           makeAssetSizesObject = sizePrinter.makeAssetSizesObject();

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-deploy-plugin": "^0.2.6",
-    "dogapi": "2.5.0"
+    "dogapi": "2.5.0",
+    "rsvp": "^3.5.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
The following console warning shows up when using the current version:
```
DEPRECATION: `ember-cli/ext/promise` is deprecated, use `rsvp` instead.
```